### PR TITLE
Proxmox検証からCloud本番への移行レビューゲートを追加

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## 概要（必須）
+
+- 変更内容:
+- 対象 Issue:
+
+## 影響範囲（必須）
+
+- 対象章/ページ:
+- 影響:
+
+## QA（必須）
+
+- [ ] `npm run build`
+- [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）
+  - 実行URLまたはログ:
+
+## Review Completion Gate（必須）
+
+- [ ] GitHub Copilot review 本文・inline comment・suggestion を全件確認した
+- [ ] 必要な修正、または修正不要理由の返信を完了した
+- [ ] `unresolved_threads=0` / `generated_count_mismatches=0` / `missing_review_ids=0` を確認した
+
+## Pages確認（原則必須）
+
+- 確認URL: https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/
+- [ ] トップページ HTTP 200
+- [ ] 主要導線 HTTP 200
+- [ ] merge 後、追加したレビュー観点が公開サイトへ反映されている
+
+## 補足
+
+- 既知の制約 / TODO:

--- a/docs/appendices/version-matrix/index.md
+++ b/docs/appendices/version-matrix/index.md
@@ -11,9 +11,10 @@ title: "検証済みバージョン一覧（Version Matrix）"
 - バージョン更新時の方針を理解できる
 - 手元の環境差分が「想定内かどうか」を判断する材料を得られる
 
-## 執筆時点
+## 執筆時点 / レビュー時点
 
-- 2026-02-23
+- 初版執筆時点: 2026-02-23
+- 内容レビュー更新: 2026-05-23（Asia/Tokyo）
 
 ## 検証対象（執筆時点の例示）
 
@@ -25,15 +26,31 @@ title: "検証済みバージョン一覧（Version Matrix）"
 
 実機検証を進めた時点で「検証済み（環境条件付き）」として更新します。
 
+## 2026-05-23 公式情報確認メモ
+
+| 項目 | 2026-05-23 時点の確認 | 本書での扱い |
+| --- | --- | --- |
+| Kubernetes | 公式 Releases では v1.36 系が最新で、サポート対象 minor は v1.36 / v1.35 / v1.34 | 本文の v1.35 例はサポート対象だが、新規構築は作業時点の supported minor と Version Skew Policy を確認する |
+| Proxmox VE | Proxmox VE 9.1 が利用可能 | 検証基盤の PVE version、snapshot / SDN / storage 差分を環境メモへ記録する |
+| ingress-nginx | 公式告知では best-effort maintenance は 2026年3月まで。その後は release / bugfix / security update が提供されない前提 | 検証例としての利用に限定し、本番では Gateway API または維持される Controller への移行計画を必須にする |
+
+参照:
+
+- [Kubernetes Releases](https://kubernetes.io/releases/)
+- [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/)
+- [Proxmox Virtual Environment 9.1 available](https://www.proxmox.com/en/about/company-details/press-releases/proxmox-virtual-environment-9-1)
+- [Kubernetes Blog: Ingress NGINX Retirement](https://www.kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
+
+
 | コンポーネント | バージョン（例示/pinned） | 備考 |
 | --- | --- | --- |
-| Proxmox VE | 環境依存 | 3ノード（第3章） |
-| Kubernetes | v1.35 系（例） | kubeadm（第4章） |
+| Proxmox VE | 環境依存（2026-05-23 時点では Proxmox VE 9.1 を公式確認） | 3ノード（第3章）。手元の PVE version とストレージ/SDN 差分を記録する |
+| Kubernetes | v1.35 系（例） / v1.36 系も確認対象 | kubeadm（第4章）。新規構築時は supported minor と Version Skew Policy を再確認する |
 | kubeadm config API | `kubeadm.k8s.io/v1beta4`（例示） | `examples/k8s/bootstrap/kubeadm-init.yaml` |
 | containerd | OS 標準（例） | CRI、`SystemdCgroup=true`（第4章） |
 | CNI | Calico `v3.31.4`（pinned） | `examples/k8s/addons/cni/calico/install.sh` |
 | MetalLB | `v0.15.3`（pinned） | `examples/k8s/addons/metallb/install.sh` |
-| Ingress Controller | ingress-nginx `controller-v1.14.3`（pinned） | Retirement 告知あり（執筆時点の best-effort は 2026年3月まで）。本番採用判断は要確認（第5章）。`examples/k8s/addons/ingress-nginx/install.sh` |
+| Ingress Controller | ingress-nginx `controller-v1.14.3`（pinned / 検証例） | 2026年3月以降は新規 release / bugfix / security update が提供されない前提。本番では Gateway API または維持される Controller への移行計画を必須にする（第5章）。`examples/k8s/addons/ingress-nginx/install.sh` |
 | Storage | local-path-provisioner `v0.0.34`（pinned） | `examples/k8s/addons/storage/local-path/install.sh` |
 | サンプルアプリ | `hashicorp/http-echo:0.2.3`（base）、`latest`（検証例） | `examples/apps/sample-app/` |
 | Kustomize | kubectl 組み込み（例） | バージョンは kubectl に依存 |

--- a/docs/chapters/chapter-05/index.md
+++ b/docs/chapters/chapter-05/index.md
@@ -89,8 +89,8 @@ kubectl apply -f examples/k8s/addons/metallb/l2advertisement.yaml
 ## Ingress（ingress-nginx と DNS/Host 設計）
 
 アプリを `Ingress` で公開するために、Ingress Controller を導入します。
-本書では例として ingress-nginx を使いますが、**ingress-nginx は Retirement（段階的終了）** が告知されています（詳細は公式告知を参照してください）。
-そのため、ここでの ingress-nginx は **検証の例示** と位置づけ、本番では組織標準/クラウド標準へ置き換える前提で読み進めてください。
+本書では例として ingress-nginx を使いますが、**ingress-nginx は Retirement（段階的終了）** が告知されています。公式告知では best-effort maintenance は 2026年3月までで、その後は新規リリース、bugfix、security update が提供されない前提です。
+そのため、ここでの ingress-nginx は **検証の例示** と位置づけ、本番では Gateway API または組織標準/クラウド標準の Ingress Controller へ置き換える前提で読み進めてください。
 
 本番の選定観点（例）:
 
@@ -98,6 +98,16 @@ kubectl apply -f examples/k8s/addons/metallb/l2advertisement.yaml
 - セキュリティ: CVE 対応の継続性、マルチテナント前提の安全性
 - 互換性: Gateway API 対応/移行方針（Ingress の将来性を含む）
 - 観測性: 組織標準の監視/ログ/トレースへ統合できるか
+
+
+本番昇格前の判定:
+
+| 判定項目 | 本番へ持ち込む条件 |
+| --- | --- |
+| Controller の保守状態 | upstream / vendor / provider の更新と security advisory を継続確認できる |
+| Gateway API / Ingress 方針 | 新規設計は Gateway API も候補に含め、既存 Ingress annotation 依存を棚卸しする |
+| TLS / DNS / LB | 証明書更新、DNS 切替、Cloud LB 課金、WAF/CDN 連携の責任者が明確である |
+| 退避策 | 切替失敗時に旧経路へ戻す条件、TTL、タイムアウト、担当者が Runbook 化されている |
 
 インストール例（Service type=LoadBalancer を前提）:
 

--- a/docs/chapters/chapter-12/index.md
+++ b/docs/chapters/chapter-12/index.md
@@ -67,16 +67,16 @@ title: "第12章：本番運用（監視/ログ/セキュリティ/バックア�
 - バックアップ: 「取得」だけでなく「復元」までを成功条件にし、RTO/RPO の現実性を点検する（復元先・停止線は要件依存）
 - アップグレード: `kubeadm upgrade plan`（または managed の標準手順）で差分を確認し、段階的更新の順序とロールバック条件を整理する
 
-## 本番昇格判定ゲート（Proxmox 検証から Cloud 本番へ）
+## 本番昇格判定ゲート（Proxmox 検証からクラウド本番へ）
 
 検証クラスタで「動いた」状態と、クラウド本番で「運用できる」状態は別物です。切替前レビューでは次を明文化します。
 
-| 領域 | Proxmox 検証で確認すること | Cloud 本番で確定すること |
+| 領域 | Proxmox 検証で確認すること | クラウド本番で確定すること |
 | --- | --- | --- |
 | Kubernetes version | kubeadm / kubelet / kubectl / アドオンの実バージョンを Version Matrix に記録する | Managed Kubernetes の supported version、upgrade window、Version Skew、provider 固有制約を確認する |
 | Ingress / Gateway | ingress-nginx 例で L7 経路と Host/TLS 設計を検証する | ingress-nginx retirement を踏まえ、Gateway API または維持される Controller を選定する |
-| Storage / Backup | local-path / NFS などで PVC と restore 手順を演習する | Cloud CSI、snapshot、backup service、RPO/RTO、cross-region / cross-zone 復旧を定義する |
-| Identity / Secret | kubeconfig / RBAC / Secret 展開の最小運用を確認する | IAM/SSO、監査ログ、Secret 管理、break-glass 手順を組織標準へ接続する |
+| Storage / Backup | local-path / NFS などで PVC と復元（リストア）手順を演習する | Cloud CSI、snapshot、backup service、RPO/RTO、cross-region / cross-zone 復旧を定義する |
+| Identity / Secret | kubeconfig / RBAC / Secret 展開の最小運用を確認する | IAM/SSO、監査ログ、Secret 管理、Break-glass（緊急時）手順を組織標準へ接続する |
 | Observability | Pod / Node / Ingress の最低限のメトリクスとログを見られる | SLO、通知、当番、ログ保持、費用、個人情報/機密情報の扱いを決める |
 | Cutover / Rollback | sample-app の切替と戻しを演習する | DNS TTL、LB 切替、データ同期、停止線、承認者、顧客影響連絡を Runbook 化する |
 

--- a/docs/chapters/chapter-12/index.md
+++ b/docs/chapters/chapter-12/index.md
@@ -67,6 +67,19 @@ title: "第12章：本番運用（監視/ログ/セキュリティ/バックア�
 - バックアップ: 「取得」だけでなく「復元」までを成功条件にし、RTO/RPO の現実性を点検する（復元先・停止線は要件依存）
 - アップグレード: `kubeadm upgrade plan`（または managed の標準手順）で差分を確認し、段階的更新の順序とロールバック条件を整理する
 
+## 本番昇格判定ゲート（Proxmox 検証から Cloud 本番へ）
+
+検証クラスタで「動いた」状態と、クラウド本番で「運用できる」状態は別物です。切替前レビューでは次を明文化します。
+
+| 領域 | Proxmox 検証で確認すること | Cloud 本番で確定すること |
+| --- | --- | --- |
+| Kubernetes version | kubeadm / kubelet / kubectl / アドオンの実バージョンを Version Matrix に記録する | Managed Kubernetes の supported version、upgrade window、Version Skew、provider 固有制約を確認する |
+| Ingress / Gateway | ingress-nginx 例で L7 経路と Host/TLS 設計を検証する | ingress-nginx retirement を踏まえ、Gateway API または維持される Controller を選定する |
+| Storage / Backup | local-path / NFS などで PVC と restore 手順を演習する | Cloud CSI、snapshot、backup service、RPO/RTO、cross-region / cross-zone 復旧を定義する |
+| Identity / Secret | kubeconfig / RBAC / Secret 展開の最小運用を確認する | IAM/SSO、監査ログ、Secret 管理、break-glass 手順を組織標準へ接続する |
+| Observability | Pod / Node / Ingress の最低限のメトリクスとログを見られる | SLO、通知、当番、ログ保持、費用、個人情報/機密情報の扱いを決める |
+| Cutover / Rollback | sample-app の切替と戻しを演習する | DNS TTL、LB 切替、データ同期、停止線、承認者、顧客影響連絡を Runbook 化する |
+
 ## “これが揃っていないなら本番にしない” 基準（例）
 
 - 監視（アラート/ログ）と当番/連絡経路が定義されている
@@ -74,6 +87,7 @@ title: "第12章：本番運用（監視/ログ/セキュリティ/バックア�
 - Secret の扱いが “組織標準” として決まっている
 - バックアップとリストア演習が実施されている
 - アップグレード計画（頻度/停止線/責任者）がある
+- ingress-nginx など保守終了コンポーネントを本番前提にしていない、または移行期限と代替策が承認されている
 
 ## 公式ドキュメント（参照）
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,16 @@ Quickstart から入る場合は、次の 3 点だけ先に固定すると迷い
 
 検証と本番の差分が気になった場合は、第2章と付録の Version Matrix / トラブルシューティングを先に確認してから本文へ戻ると判断しやすくなります。
 
+## 実務適用前の Proxmox→Cloud 移行レビューゲート
+
+本書の検証手順をクラウド本番へ昇格する前に、次の観点を必ず確認してください。
+
+- 2026-05-23（Asia/Tokyo）時点の公式情報では、Kubernetes は v1.36 系が最新で、サポート対象 minor は v1.36 / v1.35 / v1.34 です。本文の v1.35 例はまだサポート対象ですが、新規構築・移行計画では公式リリース情報と Version Skew Policy を再確認します。
+- Proxmox VE は検証基盤です。2026-05-23 時点では Proxmox VE 9.1 が利用可能であるため、手元の検証基盤との差分（VM snapshot、SDN、vTPM、ストレージ）を Version Matrix に記録します。
+- ingress-nginx は公式に Retirement が告知され、2026年3月以降は新規リリース、bugfix、security update が提供されない前提です。検証例として残す場合も、本番では Gateway API または維持されている Ingress Controller への移行計画を必須にします。
+- Proxmox 検証の MetalLB / local-path / kubeadm / ローカル認証を、クラウド本番の Load Balancer / CSI / Managed Kubernetes / IAM・SSO へどこで置き換えるかを、切替前チェックリストに落とし込みます。
+- バックアップ、DR、監視、ログ、Secret、証跡、費用、責任分界は「クラウドに移せば解決」ではありません。各 provider / 組織標準の責任範囲を確認し、復旧演習まで完了してから本番化します。
+
 ## 目次
 
 - 導入


### PR DESCRIPTION
## 概要（必須）

- 変更内容:
  - Closes #30
  - 2026-05-23（Asia/Tokyo）時点の公式情報を踏まえ、トップページに Proxmox→Cloud 移行レビューゲートを追加しました。
  - 第5章で ingress-nginx retirement を現時点の本番昇格判断に接続し、Gateway API / 維持される Controller への移行観点を補強しました。
  - 第12章に Proxmox 検証から Cloud 本番へ進むための本番昇格判定ゲートを追加しました。
  - Version Matrix を 2026-05-23 の公式確認メモで更新し、Kubernetes supported minor、Proxmox VE 9.1、ingress-nginx の本番採用リスクを明確化しました。
  - PR Review Completion Gate を含む PR テンプレートを追加しました。

## 影響範囲（必須）

- 対象章/ページ:
  - `/`（トップページ）
  - `/chapters/chapter-05/`
  - `/chapters/chapter-12/`
  - `/appendices/version-matrix/`
  - `.github/PULL_REQUEST_TEMPLATE.md`
- 影響:
  - Proxmox 検証手順をクラウド本番へ持ち込む前の責任分界、版数、Ingress/Gateway、Storage/Backup、Identity/Secret、Observability、Cutover/Rollback の確認観点を追加
  - 既存 open Issue #20（スクリーンショット取得と本文差し込み）には踏み込まず、本文レビュー観点に限定

## 公式情報確認

2026-05-23（Asia/Tokyo）に以下の一次情報を確認しました。

- Kubernetes Releases: https://kubernetes.io/releases/
- Kubernetes Version Skew Policy: https://kubernetes.io/releases/version-skew-policy/
- Proxmox Virtual Environment 9.1 available: https://www.proxmox.com/en/about/company-details/press-releases/proxmox-virtual-environment-9-1
- Kubernetes Blog: Ingress NGINX Retirement: https://www.kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/

## QA（必須）

- [x] `npm run build`: PASS
- [x] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
  - 実行URLまたはログ: local validation
  - `git diff --check`: PASS
  - `(cd docs && bundle install)`: PASS
  - `npm run build`: PASS
  - `node book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn --ignore vendor/** _site/** .bundle/**`: PASS
  - `node book-formatter/scripts/check-textlint.js docs --fail-on error --ignore vendor/** _site/** .bundle/**`: PASS
  - `node book-formatter/scripts/check-links.js docs --ignore vendor/** _site/** .bundle/**`: PASS
  - `node book-formatter/scripts/check-layout-risk.js docs --fail-on error --ignore vendor/** _site/** .bundle/**`: PASS
  - `node book-formatter/scripts/check-markdown-structure.js docs --fail-on error --ignore vendor/** _site/** .bundle/**`: PASS
  - built-site smoke（トップ、chapter05、chapter12、version-matrix の追加マーカー）: PASS

## Review Completion Gate（必須）

- [x] GitHub Copilot review 本文・inline comment・suggestion を全件確認した
- [x] 必要な修正、または修正不要理由の返信を完了した
- [x] `unresolved_threads=0` / `generated_count_mismatches=0` / `missing_review_ids=0` を確認した
- 確認結果: `status=ok`, `reviews=4`, `review_comments=6`, `review_threads=3`, `unresolved_threads=0`, `generated_count_mismatches=0`, `missing_review_ids=0`（2026-05-23）

## Pages確認（原則必須）

- 確認URL: https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/
- [x] トップページ HTTP 200（PR作成前の現行公開サイト）
- [x] 主要導線（`/chapters/chapter-05/`、`/chapters/chapter-12/`、`/appendices/version-matrix/`）HTTP 200（PR作成前の現行公開サイト）
- [x] merge 後、追加したレビュー観点が公開サイトへ反映されている

## 補足

- 既知の制約 / TODO:
  - 既存 open Issue #20（スクリーンショット取得と本文差し込み）の作業には踏み込んでいません。
  - マネージド Kubernetes / cloud provider 固有の移行手順は各 provider 仕様に依存するため、本 PR では本番昇格前の責任分界と判定ゲートに限定しています。



### merge 後確認

- Merge commit: `0d5d3b3a709235b405acb593a4aeeef449e5116e`
- main checks: Book QA success（run `26328185696`）、pages build and deployment success（run `26328185469`）
- 公開サイト: トップ、chapter05、chapter12、version-matrix が HTTP 200 かつ追加マーカー表示を確認（2026-05-23）
