### PR TITLE
Add metadata consistency gate for Kubernetes Proxmox book

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -33,6 +33,9 @@ jobs:
           cache: npm
           cache-dependency-path: book-formatter/package-lock.json
 
+      - name: Metadata consistency check
+        run: npm run check:metadata
+
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter
         run: npm ci
@@ -232,4 +235,3 @@ jobs:
 
           print(f"OK: built site smoke check passed ({len(paths)} paths, {len(required_assets)} assets)")
           PY
-

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ npm run dev
 
 `npm run dev` は `http://127.0.0.1:4000/` で起動します（`--baseurl ''`）。
 
+## 品質確認
+
+`book-config.json` を正本として、npm パッケージ情報、Jekyll 設定、トップページの
+front matter、ナビゲーション、公開アセットの整合性を確認します。
+
+```bash
+npm run check:metadata
+npm test
+```
+
 ## ローカルビルド/プレビュー（Podman）
 
 ローカルに Ruby/Bundler がない場合は、Podman を利用できます。

--- a/book-config.json
+++ b/book-config.json
@@ -170,5 +170,6 @@
       "legalNotice": true,
       "glossary": true
     }
-  }
+  },
+  "homepage": "https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
 ---
 layout: book
 title: "Kubernetes: Proxmox検証からクラウド本番へ"
+description: "Proxmox上の検証Kubernetesからクラウド上の本番Kubernetesへ移行するための設計・手順・運用を、現実的な差分（LB/Storage/Identity/Observability等）を前提に整理する実務ガイド。"
+author: "ITDO Inc."
+version: "0.1.0"
 ---
 
 # Kubernetes: Proxmox検証からクラウド本番へ

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kubernetes-proxmox-to-cloud-book",
   "version": "0.1.0",
   "private": true,
-  "description": "Proxmox 検証Kubernetesからクラウド本番Kubernetesへ移行するための設計・手順・運用ガイド",
+  "description": "Proxmox上の検証Kubernetesからクラウド上の本番Kubernetesへ移行するための設計・手順・運用を、現実的な差分（LB/Storage/Identity/Observability等）を前提に整理する実務ガイド。",
   "license": "CC-BY-NC-SA-4.0",
   "author": "ITDO Inc.",
   "repository": {
@@ -10,9 +10,15 @@
     "url": "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book.git"
   },
   "scripts": {
+    "check:metadata": "node scripts/check-metadata-consistency.js",
+    "test": "npm run check:metadata",
     "dev": "cd docs && bundle exec jekyll serve --livereload --baseurl ''",
     "build": "cd docs && bundle exec jekyll build",
     "dev:podman": "bash scripts/jekyll-podman.sh serve",
     "build:podman": "bash scripts/jekyll-podman.sh build"
+  },
+  "homepage": "https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/",
+  "bugs": {
+    "url": "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/issues"
   }
 }

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -33,10 +33,6 @@ function readJson(relPath) {
   return JSON.parse(readText(relPath));
 }
 
-function normalizeSlash(value) {
-  return String(value || '').replace(/\\/g, '/');
-}
-
 function isInside(base, target) {
   const rel = path.relative(base, target);
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
@@ -269,7 +265,7 @@ function resolveDocsPage(routePath, label) {
 function validateMetadata(config, pkg, docsConfig, indexFrontMatter, readme) {
   const repoSlug = canonicalRepoSlug(config.repository && config.repository.url);
   if (!repoSlug) {
-    addError('book-config.json repository.url must be a GitHub repository URL ending in .git.');
+    addError('book-config.json repository.url must be a GitHub repository URL.');
     return;
   }
   const repoName = repoSlug.split('/')[1];
@@ -315,10 +311,17 @@ function validateEntries(entries) {
 
   for (const entry of entries) {
     const label = `book-config.json structure.${entry.section}.${entry.id || '<missing-id>'}`;
-    if (!entry.id) addError(`${label} is missing id.`);
-    if (seenIds.has(entry.id)) addError(`${label} id is duplicated: ${entry.id}`);
-    seenIds.add(entry.id);
+    if (!entry.id) {
+      addError(`${label} is missing id.`);
+    } else {
+      if (seenIds.has(entry.id)) addError(`${label} id is duplicated: ${entry.id}`);
+      seenIds.add(entry.id);
+    }
 
+    if (!entry.path) {
+      addError(`${label}.path is missing.`);
+      continue;
+    }
     if (seenPaths.has(entry.path)) addError(`${label}.path is duplicated: ${entry.path}`);
     seenPaths.add(entry.path);
 

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function findRepoRoot(startDir) {
+  let current = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(current, 'book-config.json')) && fs.existsSync(path.join(current, 'package.json'))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error('Repository root with book-config.json and package.json was not found.');
+    }
+    current = parent;
+  }
+}
+
+const repoRoot = findRepoRoot(process.cwd());
+const repoRootReal = fs.realpathSync(repoRoot);
+const errors = [];
+
+function addError(message) {
+  errors.push(message);
+}
+
+function readText(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), 'utf8');
+}
+
+function readJson(relPath) {
+  return JSON.parse(readText(relPath));
+}
+
+function normalizeSlash(value) {
+  return String(value || '').replace(/\\/g, '/');
+}
+
+function isInside(base, target) {
+  const rel = path.relative(base, target);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+function resolveRepoPath(relPath, label, options = {}) {
+  if (typeof relPath !== 'string' || relPath.trim() === '') {
+    addError(`${label} must be a non-empty relative path.`);
+    return null;
+  }
+  if (path.isAbsolute(relPath)) {
+    addError(`${label} must be relative, got absolute path: ${relPath}`);
+    return null;
+  }
+
+  const absPath = path.resolve(repoRoot, relPath);
+  if (!isInside(repoRoot, absPath)) {
+    addError(`${label} escapes repository root: ${relPath}`);
+    return null;
+  }
+
+  if (options.mustExist) {
+    try {
+      fs.lstatSync(absPath);
+    } catch (err) {
+      addError(`${label} target not found: ${relPath}`);
+      return null;
+    }
+
+    let realPath;
+    try {
+      realPath = fs.realpathSync(absPath);
+    } catch (err) {
+      addError(`${label} cannot be resolved: ${relPath} (${err.message})`);
+      return null;
+    }
+
+    if (!isInside(repoRootReal, realPath)) {
+      addError(`${label} resolves outside repository root: ${relPath} -> ${realPath}`);
+      return null;
+    }
+
+    if (options.file && !fs.statSync(absPath).isFile()) {
+      addError(`${label} must point to a file: ${relPath}`);
+      return null;
+    }
+  }
+
+  return absPath;
+}
+
+function parseScalar(rawValue) {
+  const value = String(rawValue || '').trim();
+  if (value === '') return '';
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
+  return value;
+}
+
+function parseTopLevelYaml(text) {
+  const values = {};
+  for (const line of text.split(/\r?\n/)) {
+    if (/^\s/.test(line) || /^\s*(#|$)/.test(line)) continue;
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) continue;
+    const [, key, rawValue] = match;
+    if (rawValue.trim() === '') continue;
+    values[key] = parseScalar(rawValue);
+  }
+  return values;
+}
+
+function parseFrontMatter(markdown, relPath) {
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) {
+    addError(`${relPath} is missing YAML front matter.`);
+    return { data: {}, body: markdown };
+  }
+  return {
+    data: parseTopLevelYaml(match[1]),
+    body: markdown.slice(match[0].length),
+  };
+}
+
+function parseNavigationYaml(text) {
+  const result = {};
+  let currentSection = null;
+  let currentItem = null;
+
+  for (const line of text.split(/\r?\n/)) {
+    if (/^\s*(#|$)/.test(line)) continue;
+
+    const sectionMatch = line.match(/^([A-Za-z0-9_-]+):\s*$/);
+    if (sectionMatch) {
+      currentSection = sectionMatch[1];
+      result[currentSection] = [];
+      currentItem = null;
+      continue;
+    }
+
+    if (!currentSection) continue;
+
+    const titleMatch = line.match(/^\s*-\s+title:\s*(.+)$/);
+    if (titleMatch) {
+      currentItem = { title: parseScalar(titleMatch[1]) };
+      result[currentSection].push(currentItem);
+      continue;
+    }
+
+    const pathMatch = line.match(/^\s+path:\s*(.+)$/);
+    if (pathMatch && currentItem) {
+      currentItem.path = parseScalar(pathMatch[1]);
+    }
+  }
+
+  return result;
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    addError(`${label} mismatch: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertContains(haystack, needle, label) {
+  if (!haystack.includes(needle)) {
+    addError(`${label} does not contain ${JSON.stringify(needle)}.`);
+  }
+}
+
+function acceptablePageTitles(entry) {
+  const titles = [entry.title];
+  if (entry.section === 'appendices' && entry.title.startsWith('付録：')) {
+    titles.push(entry.title.replace(/^付録：/, ''));
+  }
+  return titles;
+}
+
+function canonicalRepoSlug(repositoryUrl) {
+  const match = String(repositoryUrl || '').match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
+  return match ? match[1] : null;
+}
+
+function normalizeHomepage(value) {
+  const raw = String(value || '');
+  return raw.endsWith('/') ? raw : `${raw}/`;
+}
+
+function pagesCoordinates(homepage) {
+  try {
+    const parsed = new URL(homepage);
+    const pathname = parsed.pathname.endsWith('/') ? parsed.pathname.slice(0, -1) : parsed.pathname;
+    return {
+      url: parsed.origin,
+      baseurl: pathname === '/' ? '' : pathname,
+    };
+  } catch (err) {
+    addError(`book-config.json homepage must be a valid URL: ${homepage}`);
+    return null;
+  }
+}
+
+function collectEntries(config) {
+  const structure = config.structure || {};
+  const entries = [];
+  for (const section of ['introduction', 'chapters', 'appendices', 'afterword']) {
+    const items = structure[section] || [];
+    if (!Array.isArray(items)) {
+      addError(`book-config.json structure.${section} must be an array.`);
+      continue;
+    }
+    for (const item of items) {
+      entries.push({ ...item, section });
+    }
+  }
+  return entries;
+}
+
+function docsCandidatesForPath(routePath, label) {
+  if (typeof routePath !== 'string' || routePath.trim() === '') {
+    addError(`${label} must be a non-empty route path.`);
+    return [];
+  }
+  if (!routePath.startsWith('/')) {
+    addError(`${label} must start with '/': ${routePath}`);
+    return [];
+  }
+  if (/^https?:\/\//.test(routePath) || routePath.includes('://')) {
+    addError(`${label} must be an internal route path: ${routePath}`);
+    return [];
+  }
+
+  const withoutQuery = routePath.split(/[?#]/, 1)[0];
+  const segments = withoutQuery.split('/').filter(Boolean);
+  if (segments.some((segment) => segment === '..' || segment === '.')) {
+    addError(`${label} must not contain relative path segments: ${routePath}`);
+    return [];
+  }
+
+  if (!withoutQuery.endsWith('/')) {
+    addError(`${label} should use a directory-style permalink ending with '/': ${routePath}`);
+  }
+
+  if (segments.length === 0) {
+    return ['docs/index.md'];
+  }
+
+  return [
+    path.join('docs', ...segments) + '.md',
+    path.join('docs', ...segments, 'index.md'),
+  ];
+}
+
+function resolveDocsPage(routePath, label) {
+  const candidates = docsCandidatesForPath(routePath, label);
+  for (const candidate of candidates) {
+    const abs = resolveRepoPath(candidate, `${label} candidate`, { mustExist: false });
+    if (!abs) continue;
+    if (!fs.existsSync(abs)) continue;
+    return resolveRepoPath(candidate, `${label} target`, { mustExist: true, file: true });
+  }
+  addError(`${label} target page not found for route ${routePath}; tried ${candidates.join(', ')}`);
+  return null;
+}
+
+function validateMetadata(config, pkg, docsConfig, indexFrontMatter, readme) {
+  const repoSlug = canonicalRepoSlug(config.repository && config.repository.url);
+  if (!repoSlug) {
+    addError('book-config.json repository.url must be a GitHub repository URL ending in .git.');
+    return;
+  }
+  const repoName = repoSlug.split('/')[1];
+  const pages = pagesCoordinates(config.homepage);
+
+  assertEqual(pkg.name, repoName, 'package.json name');
+  assertEqual(pkg.version, config.version, 'package.json version');
+  assertEqual(pkg.description, config.description, 'package.json description');
+  assertEqual(pkg.author, config.author, 'package.json author');
+  assertEqual(pkg.license, config.license, 'package.json license');
+  assertEqual(pkg.repository && pkg.repository.type, 'git', 'package.json repository.type');
+  assertEqual(pkg.repository && pkg.repository.url, config.repository.url, 'package.json repository.url');
+  assertEqual(normalizeHomepage(pkg.homepage), config.homepage, 'package.json homepage');
+  assertEqual(pkg.bugs && pkg.bugs.url, `https://github.com/${repoSlug}/issues`, 'package.json bugs.url');
+
+  assertEqual(docsConfig.title, config.title, 'docs/_config.yml title');
+  assertEqual(docsConfig.description, config.description, 'docs/_config.yml description');
+  assertEqual(docsConfig.author, config.author, 'docs/_config.yml author');
+  assertEqual(docsConfig.version, config.version, 'docs/_config.yml version');
+  assertEqual(docsConfig.lang, config.language, 'docs/_config.yml lang');
+  assertEqual(docsConfig.repository, repoSlug, 'docs/_config.yml repository');
+  assertEqual(docsConfig.repository_branch, config.repository.branch, 'docs/_config.yml repository_branch');
+  assertEqual(docsConfig.repository_docs_path, 'docs', 'docs/_config.yml repository_docs_path');
+  if (pages) {
+    assertEqual(docsConfig.url, pages.url, 'docs/_config.yml url');
+    assertEqual(docsConfig.baseurl, pages.baseurl, 'docs/_config.yml baseurl');
+  }
+
+  assertEqual(indexFrontMatter.layout, 'book', 'docs/index.md front matter layout');
+  assertEqual(indexFrontMatter.title, config.title, 'docs/index.md front matter title');
+  assertEqual(indexFrontMatter.description, config.description, 'docs/index.md front matter description');
+  assertEqual(indexFrontMatter.author, config.author, 'docs/index.md front matter author');
+  assertEqual(indexFrontMatter.version, config.version, 'docs/index.md front matter version');
+
+  assertContains(readme, config.homepage, 'README.md online URL');
+  assertContains(readme, 'npm run check:metadata', 'README.md quality gate');
+  assertContains(readme, 'npm test', 'README.md test command');
+}
+
+function validateEntries(entries) {
+  const seenIds = new Set();
+  const seenPaths = new Set();
+
+  for (const entry of entries) {
+    const label = `book-config.json structure.${entry.section}.${entry.id || '<missing-id>'}`;
+    if (!entry.id) addError(`${label} is missing id.`);
+    if (seenIds.has(entry.id)) addError(`${label} id is duplicated: ${entry.id}`);
+    seenIds.add(entry.id);
+
+    if (seenPaths.has(entry.path)) addError(`${label}.path is duplicated: ${entry.path}`);
+    seenPaths.add(entry.path);
+
+    const docsAbs = resolveDocsPage(entry.path, `${label}.path`);
+    if (!docsAbs) continue;
+
+    const relPath = path.relative(repoRoot, docsAbs);
+    const parsed = parseFrontMatter(fs.readFileSync(docsAbs, 'utf8'), relPath);
+    assertEqual(parsed.data.layout, 'book', `${relPath} front matter layout`);
+    const pageTitles = acceptablePageTitles(entry);
+    if (!pageTitles.includes(parsed.data.title)) {
+      addError(`${relPath} front matter title mismatch: expected one of ${JSON.stringify(pageTitles)}, got ${JSON.stringify(parsed.data.title)}`);
+    }
+  }
+}
+
+function validateNavigation(config, nav) {
+  const expected = {};
+  for (const section of ['introduction', 'chapters', 'appendices', 'afterword']) {
+    expected[section] = Array.isArray(config.structure && config.structure[section])
+      ? config.structure[section]
+      : [];
+  }
+  const expectedSections = new Set(Object.keys(expected));
+
+  for (const section of Object.keys(nav)) {
+    if (!expectedSections.has(section)) {
+      addError(`docs/_data/navigation.yml has unexpected section: ${section}`);
+    }
+  }
+
+  for (const section of Object.keys(expected)) {
+    const actualItems = nav[section] || [];
+    const expectedItems = expected[section];
+    assertEqual(actualItems.length, expectedItems.length, `docs/_data/navigation.yml ${section} item count`);
+    const max = Math.min(actualItems.length, expectedItems.length);
+    for (let i = 0; i < max; i += 1) {
+      assertEqual(actualItems[i].title, expectedItems[i].title, `docs/_data/navigation.yml ${section}[${i}].title`);
+      assertEqual(actualItems[i].path, expectedItems[i].path, `docs/_data/navigation.yml ${section}[${i}].path`);
+      resolveDocsPage(actualItems[i].path, `docs/_data/navigation.yml ${section}[${i}].path`);
+    }
+  }
+}
+
+function validateRequiredAssets() {
+  const requiredAssets = [
+    'docs/assets/css/main.css',
+    'docs/assets/css/syntax-highlighting.css',
+    'docs/assets/js/theme.js',
+    'docs/assets/js/search.js',
+    'docs/assets/js/code-copy-lightweight.js',
+  ];
+  for (const relPath of requiredAssets) {
+    resolveRepoPath(relPath, `required asset ${relPath}`, { mustExist: true, file: true });
+  }
+}
+
+function main() {
+  const config = readJson('book-config.json');
+  const pkg = readJson('package.json');
+  const docsConfig = parseTopLevelYaml(readText('docs/_config.yml'));
+  const index = parseFrontMatter(readText('docs/index.md'), 'docs/index.md');
+  const nav = parseNavigationYaml(readText('docs/_data/navigation.yml'));
+  const readme = readText('README.md');
+  const entries = collectEntries(config);
+
+  validateMetadata(config, pkg, docsConfig, index.data, readme);
+  validateEntries(entries);
+  validateNavigation(config, nav);
+  validateRequiredAssets();
+
+  if (errors.length > 0) {
+    console.error('❌ Metadata consistency check failed:');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`✅ Metadata consistency check passed (${entries.length} configured pages).`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `scripts/check-metadata-consistency.js` to validate `book-config.json` against package metadata, Jekyll config, top-page front matter, navigation, configured page targets, and required public assets
- add `npm run check:metadata` / `npm test`, document the quality gate, and wire metadata validation into Book QA
- add canonical Pages homepage metadata and align package/top-page metadata with `book-config.json`

Part of itdojp/it-engineer-knowledge-architecture#152.

## Verification
- `node --check scripts/check-metadata-consistency.js`
- `npm run check:metadata`
- `(cd docs && node ../scripts/check-metadata-consistency.js)`
- metadata fixtures: unexpected nav section fails, missing nav target fails, route path traversal fails, symlink escape fails, renamed Pages coordinates pass when canonical metadata is updated
- `npm test`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/kptc-bundle-path BUNDLE_APP_CONFIG=/home/devuser/work/CodeX/booksB/.codex-local/tmp/kptc-bundle-config npm run build`
- Jekyll build and built-site smoke for `/`, `/chapters/chapter-03/`, `/appendices/version-matrix/`
- book-formatter checks: Unicode, textlint/PRH, internal links, layout risk, markdown structure
- `git diff --check`