### PR TITLE
chore: add reproducible npm QA gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -31,10 +31,18 @@ jobs:
         with:
           node-version: '20'
           cache: npm
-          cache-dependency-path: book-formatter/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            book-formatter/package-lock.json
 
-      - name: Metadata consistency check
-        run: npm run check:metadata
+      - name: Install local npm dependencies
+        run: npm ci
+
+      - name: Local npm security audit
+        run: npm run check:security
+
+      - name: Local npm QA
+        run: npm test
 
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 # Jekyll (under docs/)
 docs/_site/
 docs/.jekyll-cache/
+docs/.jekyll-metadata
 docs/.sass-cache/
 docs/.bundle/
 docs/vendor/
@@ -15,4 +16,3 @@ Thumbs.db
 
 # Temp
 *.tmp
-

--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@
 
 ## ローカル開発（前提）
 
-- Node.js（`npm` 実行用）
+- Node.js 20+（`npm` 実行用。CI は Node.js 20 を使用）
 - Ruby + Bundler（Jekyll 実行用）
 
 ## ローカルビルド/プレビュー
 
 ```bash
+npm ci
+
 cd docs
 bundle install
 cd ..
@@ -41,6 +43,7 @@ npm run dev
 front matter、ナビゲーション、公開アセットの整合性を確認します。
 
 ```bash
+npm run check:security
 npm run check:metadata
 npm test
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "kubernetes-proxmox-to-cloud-book",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kubernetes-proxmox-to-cloud-book",
+      "version": "0.1.0",
+      "license": "CC-BY-NC-SA-4.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   },
   "scripts": {
     "check:metadata": "node scripts/check-metadata-consistency.js",
+    "check:security": "npm audit",
     "test": "npm run check:metadata",
-    "dev": "cd docs && bundle exec jekyll serve --livereload --baseurl ''",
-    "build": "cd docs && bundle exec jekyll build",
+    "dev": "cd docs && (bundle check || bundle install) && bundle exec jekyll serve --livereload --baseurl ''",
+    "build": "cd docs && (bundle check || bundle install) && bundle exec jekyll build",
     "dev:podman": "bash scripts/jekyll-podman.sh serve",
     "build:podman": "bash scripts/jekyll-podman.sh build"
   },

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -30,7 +30,12 @@ function readText(relPath) {
 }
 
 function readJson(relPath) {
-  return JSON.parse(readText(relPath));
+  try {
+    return JSON.parse(readText(relPath));
+  } catch (err) {
+    addError(`${relPath} must be readable JSON: ${err.message}`);
+    return {};
+  }
 }
 
 function isInside(base, target) {

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -262,7 +262,7 @@ function resolveDocsPage(routePath, label) {
   return null;
 }
 
-function validateMetadata(config, pkg, docsConfig, indexFrontMatter, readme) {
+function validateMetadata(config, pkg, lockRoot, docsConfig, indexFrontMatter, readme) {
   const repoSlug = canonicalRepoSlug(config.repository && config.repository.url);
   if (!repoSlug) {
     addError('book-config.json repository.url must be a GitHub repository URL.');
@@ -280,6 +280,10 @@ function validateMetadata(config, pkg, docsConfig, indexFrontMatter, readme) {
   assertEqual(pkg.repository && pkg.repository.url, config.repository.url, 'package.json repository.url');
   assertEqual(normalizeHomepage(pkg.homepage), config.homepage, 'package.json homepage');
   assertEqual(pkg.bugs && pkg.bugs.url, `https://github.com/${repoSlug}/issues`, 'package.json bugs.url');
+
+  assertEqual(lockRoot.name, pkg.name, 'package-lock root name');
+  assertEqual(lockRoot.version, pkg.version, 'package-lock root version');
+  assertEqual(lockRoot.license, pkg.license, 'package-lock root license');
 
   assertEqual(docsConfig.title, config.title, 'docs/_config.yml title');
   assertEqual(docsConfig.description, config.description, 'docs/_config.yml description');
@@ -382,13 +386,15 @@ function validateRequiredAssets() {
 function main() {
   const config = readJson('book-config.json');
   const pkg = readJson('package.json');
+  const lock = readJson('package-lock.json');
+  const lockRoot = lock.packages && lock.packages[''] ? lock.packages[''] : {};
   const docsConfig = parseTopLevelYaml(readText('docs/_config.yml'));
   const index = parseFrontMatter(readText('docs/index.md'), 'docs/index.md');
   const nav = parseNavigationYaml(readText('docs/_data/navigation.yml'));
   const readme = readText('README.md');
   const entries = collectEntries(config);
 
-  validateMetadata(config, pkg, docsConfig, index.data, readme);
+  validateMetadata(config, pkg, lockRoot, docsConfig, index.data, readme);
   validateEntries(entries);
   validateNavigation(config, nav);
   validateRequiredAssets();


### PR DESCRIPTION
## Summary
- Add a tracked root `package-lock.json` so `npm ci` can be used reproducibly for repository QA.
- Add `npm run check:security` (`npm audit`) and validate package-lock root metadata in the existing metadata consistency gate.
- Run root `npm ci`, `npm run check:security`, and `npm test` in Book QA, and include `package-lock.json` in the npm cache key.
- Make local `dev` / `build` run `bundle check || bundle install` before Jekyll so missing gems do not block local builds.
- Update README to document `npm ci`, Node.js 20+, and the security check; ignore `docs/.jekyll-metadata`.

## Scope note
- Existing open Issue #20 is about screenshot capture/insertion. This PR does not change screenshot content; it only improves the repository QA/security gate used by this quality sprint.

## Evidence
- Baseline had no root `package-lock.json`, so `npm ci` could not be used for the root package.
- Baseline `npm audit` after lockfile generation: 0 vulnerabilities.
- Updated metadata gate checks `package-lock.json` root `name`, `version`, and `license` against `package.json`.

## Local verification
- `npm ci`
- `npm run check:security`
- `npm run check:metadata`
- `npm test`
- `npm run build` with workspace-local Bundler path
- Built HTML smoke: `docs/_site/index.html`, `docs/_site/introduction/quickstart/index.html`, `docs/_site/chapters/chapter-03/index.html`, `docs/_site/chapters/chapter-11/index.html`
- Workflow YAML parse for `.github/workflows/book-qa.yml` and `.github/workflows/nav-link-check.yml`
- Pinned `book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`: unicode, textlint, links, layout-risk, markdown-structure
- `git diff --check`