### PR TITLE
fix: 公開内容にUX figure index metadataを合わせる

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -166,7 +166,7 @@
       "checklistPack": true,
       "troubleshootingFlow": true,
       "conceptMap": false,
-      "figureIndex": true,
+      "figureIndex": false,
       "legalNotice": true,
       "glossary": true
     }


### PR DESCRIPTION
## 概要

Quickstart、読み方ガイド、チェックリスト、トラブルシューティング、ライセンスFAQ、用語集は公開実体がありますが、reader-facingな専用図表索引はありません。

公開実態に合わせ、`book-config.json`の`figureIndex`を`false`へ補正します。他のmodule値は変更しません。Profile Bの専用`figureIndex`不足はitdojp/it-engineer-knowledge-architecture#215で分離追跡します。

## 検証

- `npm ci`
- `npm test`
- `npm audit`（0 vulnerabilities）
- `npm run build`
- `git diff --check`

Closes #39
