### PR TITLE
fix: Proxmox VE版数スナップショットを9.2へ更新

### DIFF
--- a/docs/appendices/version-matrix/index.md
+++ b/docs/appendices/version-matrix/index.md
@@ -14,7 +14,8 @@ title: "検証済みバージョン一覧（Version Matrix）"
 ## 執筆時点 / レビュー時点
 
 - 初版執筆時点: 2026-02-23
-- 内容レビュー更新: 2026-05-23（Asia/Tokyo）
+- **情報の確認日**: 2026-05-23（Asia/Tokyo）
+- Proxmox VE の**確認日時点の現行版**と**本書で検証した版**は、下記の公式情報確認メモで区別する。実機検証の環境条件と証跡がない版は「検証済み」とは扱わない
 
 ## 検証対象（執筆時点の例示）
 
@@ -31,20 +32,20 @@ title: "検証済みバージョン一覧（Version Matrix）"
 | 項目 | 2026-05-23 時点の確認 | 本書での扱い |
 | --- | --- | --- |
 | Kubernetes | 公式 Releases では v1.36 系が最新で、サポート対象 minor は v1.36 / v1.35 / v1.34 | 本文の v1.35 例はサポート対象だが、新規構築は作業時点の supported minor と Version Skew Policy を確認する |
-| Proxmox VE | Proxmox VE 9.1 が利用可能 | 検証基盤の PVE version、snapshot / SDN / storage 差分を環境メモへ記録する |
+| Proxmox VE | **情報の確認日**: 2026-05-23（Asia/Tokyo）。**確認日時点の現行版**: Proxmox VE 9.2（2026-05-21 公開） | **本書で検証した版**: 実機検証した版の記録なし（検証済みとは扱わない）。検証基盤の PVE version、snapshot / SDN / storage 差分を環境メモへ記録する |
 | ingress-nginx | 公式告知では best-effort maintenance は 2026年3月まで。その後は release / bugfix / security update が提供されない前提 | 検証例としての利用に限定し、本番では Gateway API または維持される Controller への移行計画を必須にする |
 
 参照:
 
 - [Kubernetes Releases](https://kubernetes.io/releases/)
 - [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/)
-- [Proxmox Virtual Environment 9.1 available](https://www.proxmox.com/en/about/company-details/press-releases/proxmox-virtual-environment-9-1)
+- [Proxmox Virtual Environment 9.2 available](https://www.proxmox.com/en/about/company-details/press-releases/proxmox-virtual-environment-9-2)
 - [Kubernetes Blog: Ingress NGINX Retirement](https://www.kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
 
 
 | コンポーネント | バージョン（例示/pinned） | 備考 |
 | --- | --- | --- |
-| Proxmox VE | 環境依存（2026-05-23 時点では Proxmox VE 9.1 を公式確認） | 3ノード（第3章）。手元の PVE version とストレージ/SDN 差分を記録する |
+| Proxmox VE | 環境依存（固定版なし。2026-05-23 確認時点の現行版は 9.2） | **本書で実機検証した版**: 記録なし（検証済みとは扱わない）。3ノード（第3章）。手元の PVE version とストレージ/SDN 差分を記録する |
 | Kubernetes | v1.35 系（例） / v1.36 系も確認対象 | kubeadm（第4章）。新規構築時は supported minor と Version Skew Policy を再確認する |
 | kubeadm config API | `kubeadm.k8s.io/v1beta4`（例示） | `examples/k8s/bootstrap/kubeadm-init.yaml` |
 | containerd | OS 標準（例） | CRI、`SystemdCgroup=true`（第4章） |

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ Quickstart から入る場合は、次の 3 点だけ先に固定すると迷い
 本書の検証手順をクラウド本番へ昇格する前に、次の観点を必ず確認してください。
 
 - 2026-05-23（Asia/Tokyo）時点の公式情報では、Kubernetes は v1.36 系が最新で、サポート対象 minor は v1.36 / v1.35 / v1.34 です。本文の v1.35 例はまだサポート対象ですが、新規構築・移行計画では公式リリース情報と Version Skew Policy を再確認します。
-- Proxmox VE は検証基盤です。2026-05-23 時点では Proxmox VE 9.1 が利用可能であるため、手元の検証基盤との差分（VM snapshot、SDN、vTPM、ストレージ）を Version Matrix に記録します。
+- Proxmox VE は検証基盤です。**情報の確認日**は 2026-05-23（Asia/Tokyo）で、**確認日時点の現行版**は 2026-05-21 公開の Proxmox VE 9.2 です。**本書で実機検証した版**は記録がないため、検証済み版を主張しません。手元の検証基盤と現行版の差分（VM snapshot、SDN、vTPM、ストレージ）は Version Matrix に記録します。
 - ingress-nginx は公式に Retirement が告知され、2026年3月以降は新規リリース、bugfix、security update が提供されない前提です。検証例として残す場合も、本番では Gateway API または維持されている Ingress Controller への移行計画を必須にします。
 - Proxmox 検証の MetalLB / local-path / kubeadm / ローカル認証を、クラウド本番の Load Balancer / CSI / Managed Kubernetes / IAM・SSO へどこで置き換えるかを、切替前チェックリストに落とし込みます。
 - バックアップ、DR、監視、ログ、Secret、証跡、費用、責任分界は「クラウドに移せば解決」ではありません。各 provider / 組織標準の責任範囲を確認し、復旧演習まで完了してから本番化します。

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   },
   "scripts": {
     "check:metadata": "node scripts/check-metadata-consistency.js",
+    "check:proxmox-version-snapshot": "node scripts/check-proxmox-version-snapshot.js",
+    "check:proxmox-version-snapshot:self-test": "node scripts/check-proxmox-version-snapshot.js --self-test",
     "check:security": "npm audit",
-    "test": "npm run check:metadata",
+    "test": "npm run check:metadata && npm run check:proxmox-version-snapshot && npm run check:proxmox-version-snapshot:self-test",
     "dev": "cd docs && (bundle check || bundle install) && bundle exec jekyll serve --livereload --baseurl ''",
     "build": "cd docs && (bundle check || bundle install) && bundle exec jekyll build",
     "dev:podman": "bash scripts/jekyll-podman.sh serve",

--- a/scripts/check-proxmox-version-snapshot.js
+++ b/scripts/check-proxmox-version-snapshot.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const REQUIRED_MARKERS = {
+  'docs/index.md': [
+    '情報の確認日**は 2026-05-23（Asia/Tokyo）',
+    '確認日時点の現行版**は 2026-05-21 公開の Proxmox VE 9.2',
+    '本書で実機検証した版**は記録がないため、検証済み版を主張しません',
+  ],
+  'docs/appendices/version-matrix/index.md': [
+    '情報の確認日',
+    '確認日時点の現行版',
+    '本書で検証した版',
+    'Proxmox VE 9.2（2026-05-21 公開）',
+    '実機検証した版の記録なし（検証済みとは扱わない）',
+    'proxmox-virtual-environment-9-2',
+  ],
+};
+
+const STALE_CURRENT_91_PATTERNS = [
+  /Proxmox VE 9\.1[^\n]{0,80}(?:が利用可能|が現行版|を現行版|を最新(?:版)?)/,
+  /(?:確認日時点|確認時点|2026-05-23 時点)[^\n]{0,120}(?:現行版|最新(?:版)?|利用可能)[^\n]{0,80}(?:Proxmox VE )?9\.1/,
+  /(?:確認日時点|確認時点|2026-05-23 時点)[^\n]{0,120}(?:Proxmox VE )?9\.1[^\n]{0,80}(?:公式確認|利用可能|現行版|最新(?:版)?)/,
+];
+
+function collectMarkdownFiles(directory) {
+  if (!fs.existsSync(directory)) return [];
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === '_site') return [];
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return collectMarkdownFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith('.md') ? [entryPath] : [];
+  });
+}
+
+function checkSnapshot(contents) {
+  const errors = [];
+
+  for (const [relPath, markers] of Object.entries(REQUIRED_MARKERS)) {
+    const content = contents[relPath];
+    if (typeof content !== 'string') {
+      errors.push(`${relPath} could not be read.`);
+      continue;
+    }
+    for (const marker of markers) {
+      if (!content.includes(marker)) {
+        errors.push(`${relPath} is missing required marker: ${marker}`);
+      }
+    }
+  }
+
+  for (const [relPath, content] of Object.entries(contents)) {
+    for (const pattern of STALE_CURRENT_91_PATTERNS) {
+      if (pattern.test(content)) {
+        errors.push(`${relPath} retains stale wording that presents Proxmox VE 9.1 as current on 2026-05-23.`);
+        break;
+      }
+    }
+  }
+
+  return errors;
+}
+
+function readContents() {
+  const candidates = [path.join(repoRoot, 'README.md'), ...collectMarkdownFiles(path.join(repoRoot, 'docs'))]
+    .filter((filePath) => fs.existsSync(filePath));
+  return Object.fromEntries(candidates.map((filePath) => [
+    path.relative(repoRoot, filePath),
+    fs.readFileSync(filePath, 'utf8'),
+  ]));
+}
+
+function runSelfTest() {
+  const staleContents = readContents();
+  staleContents['docs/appendices/version-matrix/index.md'] += '\n2026-05-23 時点では Proxmox VE 9.1 を公式確認。\n';
+  const staleErrors = checkSnapshot(staleContents);
+  if (!staleErrors.some((error) => error.includes('presents Proxmox VE 9.1 as current'))) {
+    console.error('❌ Proxmox version snapshot self-test failed: stale 9.1 current wording was not rejected.');
+    process.exit(1);
+  }
+
+  const historicalContents = readContents();
+  historicalContents['README.md'] = `${historicalContents['README.md'] || ''}\nProxmox VE 9.1 は歴史的な検証対象として記録する。\n`;
+  const historicalErrors = checkSnapshot(historicalContents);
+  if (historicalErrors.length > 0) {
+    console.error(`❌ Proxmox version snapshot self-test failed: historical 9.1 wording was rejected:\n- ${historicalErrors.join('\n- ')}`);
+    process.exit(1);
+  }
+
+  console.log('✅ Proxmox version snapshot self-test passed (stale current wording rejected; historical wording accepted).');
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    runSelfTest();
+    return;
+  }
+
+  const errors = checkSnapshot(readContents());
+  if (errors.length > 0) {
+    console.error('❌ Proxmox version snapshot check failed:');
+    for (const error of errors) console.error(`- ${error}`);
+    process.exit(1);
+  }
+  console.log('✅ Proxmox version snapshot check passed.');
+}
+
+main();

--- a/scripts/check-proxmox-version-snapshot.js
+++ b/scripts/check-proxmox-version-snapshot.js
@@ -22,6 +22,7 @@ const REQUIRED_MARKERS = {
 
 const STALE_CURRENT_91_PATTERNS = [
   /Proxmox VE 9\.1[^\n]{0,80}(?:が利用可能|が現行版|を現行版|を最新(?:版)?)/,
+  /Proxmox VE 9\.1[^\n]{0,120}(?:現行版|最新(?:版)?)/,
   /(?:確認日時点|確認時点|2026-05-23 時点)[^\n]{0,120}(?:現行版|最新(?:版)?|利用可能)[^\n]{0,80}(?:Proxmox VE )?9\.1/,
   /(?:確認日時点|確認時点|2026-05-23 時点)[^\n]{0,120}(?:Proxmox VE )?9\.1[^\n]{0,80}(?:公式確認|利用可能|現行版|最新(?:版)?)/,
 ];
@@ -55,7 +56,7 @@ function checkSnapshot(contents) {
   for (const [relPath, content] of Object.entries(contents)) {
     for (const pattern of STALE_CURRENT_91_PATTERNS) {
       if (pattern.test(content)) {
-        errors.push(`${relPath} retains stale wording that presents Proxmox VE 9.1 as current on 2026-05-23.`);
+        errors.push(`${relPath} retains stale wording that presents Proxmox VE 9.1 as current.`);
         break;
       }
     }
@@ -68,18 +69,24 @@ function readContents() {
   const candidates = [path.join(repoRoot, 'README.md'), ...collectMarkdownFiles(path.join(repoRoot, 'docs'))]
     .filter((filePath) => fs.existsSync(filePath));
   return Object.fromEntries(candidates.map((filePath) => [
-    path.relative(repoRoot, filePath),
+    path.relative(repoRoot, filePath).split(path.sep).join('/'),
     fs.readFileSync(filePath, 'utf8'),
   ]));
 }
 
 function runSelfTest() {
-  const staleContents = readContents();
-  staleContents['docs/appendices/version-matrix/index.md'] += '\n2026-05-23 時点では Proxmox VE 9.1 を公式確認。\n';
-  const staleErrors = checkSnapshot(staleContents);
-  if (!staleErrors.some((error) => error.includes('presents Proxmox VE 9.1 as current'))) {
-    console.error('❌ Proxmox version snapshot self-test failed: stale 9.1 current wording was not rejected.');
-    process.exit(1);
+  for (const staleWording of [
+    '2026-05-23 時点では Proxmox VE 9.1 を公式確認。',
+    'Proxmox VE 9.1 は、2026-05-23 時点の現行版です。',
+  ]) {
+    const staleContents = readContents();
+    staleContents['docs/appendices/version-matrix/index.md'] = (staleContents['docs/appendices/version-matrix/index.md'] || '')
+      + `\n${staleWording}\n`;
+    const staleErrors = checkSnapshot(staleContents);
+    if (!staleErrors.some((error) => error.includes('presents Proxmox VE 9.1 as current'))) {
+      console.error(`❌ Proxmox version snapshot self-test failed: stale wording was not rejected: ${staleWording}`);
+      process.exit(1);
+    }
   }
 
   const historicalContents = readContents();


### PR DESCRIPTION
## 概要

Proxmox VE の版数スナップショットを、2026-05-23確認時点で公開済みだった 9.2 と整合させます。

## 変更内容

- 情報確認日、確認日時点の現行版、本書で実機検証した版を明確に分離
- 現行版を Proxmox VE 9.2（2026-05-21公開）へ更新
- README と `docs/**/*.md` を横断する版数スナップショット検査を追加
- stale な「9.1が現行」表現は拒否し、明示的な歴史的言及は許可する自己テストを追加

## 検証

- `mise exec node@24 -- npm ci`
- `mise exec node@24 -- npm test`
- `mise exec node@24 -- npm run build`
- `mise exec node@24 -- npm audit --omit=optional`
- `git diff --check`

すべて成功しました。Jekyll build の既存 `faraday-retry` 推奨 warning は非致命で、本変更による追加エラーはありません。

Closes #46
